### PR TITLE
build: bump to Go 1.27

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ test:
 
 lint:
 	go vet -v ./...
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	golangci-lint run
 	go install honnef.co/go/tools/cmd/staticcheck@latest
 	staticcheck -checks all ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/x-way/exec-hookd
 
-go 1.24.6
+go 1.27.0


### PR DESCRIPTION
Bump the go.mod language version to Go 1.27.