### PR TITLE
security: explicit workflow permissions + persist-credentials:false on checkout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,9 @@ name: Build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   lint-and-build:
     strategy:
@@ -15,6 +18,8 @@ jobs:
           go-version: 'stable'
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Lint
         if: matrix.platform == 'ubuntu-latest'
         run: make lint


### PR DESCRIPTION
Implements tasks #13 and #14 from the x-way GitHub Actions security review.

- .github/workflows/build.yml: added explicit `permissions: contents: read` (workflow had none); added `persist-credentials: false` to the actions/checkout step.