### PR TITLE
security: pin third-party actions to commit SHA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
           go-version: 'stable'
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
       - name: Lint


### PR DESCRIPTION
Implements task #08 from the x-way GitHub Actions security review: pins every third-party `uses:` reference to its full commit SHA instead of a mutable tag, original tag kept as a trailing comment. Where applicable, the repo's `allowed_actions=selected` allowlist was additively updated beforehand to include the new SHA-based patterns alongside the existing tag-based ones.