### PR TITLE
ci: add Dependabot coverage for github-actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
Implements task #12 from the x-way GitHub Actions security review: adds `.github/dependabot.yml` with a `github-actions` package-ecosystem entry (daily) so action version bumps get automated PRs. Since all actions are now SHA-pinned (task #08), Dependabot will bump the SHA and the version comment together.